### PR TITLE
Remove *a, **k from poll signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ polling.poll(
 
 # Release notes
 
+## 0.4.0
+- Creation of polling2, forked from polling as previous maintainer seems to be ignoring issues and pull-requests.
+- Remove ```*a, **k``` from poll signature. This allows Type errors to be raised if caller spells arguments into correctly, making bugs easier to find.
+
 ## 0.3.0
 
 - Support Python 3.4+

--- a/polling.py
+++ b/polling.py
@@ -42,7 +42,7 @@ def is_truthy(val):
 
 
 def poll(target, step, args=(), kwargs=None, timeout=None, max_tries=None, check_success=is_truthy,
-         step_function=step_constant, ignore_exceptions=(), poll_forever=False, collect_values=None, *a, **k):
+         step_function=step_constant, ignore_exceptions=(), poll_forever=False, collect_values=None):
     """Poll by calling a target function until a certain condition is met. You must specify at least a target
     function to be called and the step -- base wait time between each function call.
 

--- a/polling.py
+++ b/polling.py
@@ -1,6 +1,6 @@
 """Polling module containing all exceptions and helpers used for the polling function"""
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 import time
 try:


### PR DESCRIPTION
Allows typeerrors to be raised if caller spells arguments into correctly, making bugs easier to find